### PR TITLE
HTTP request parameters in table

### DIFF
--- a/docs/authentication/client-credentials.md
+++ b/docs/authentication/client-credentials.md
@@ -29,19 +29,9 @@ Replace the `{CLIENT_ID}` and `{CLIENT_SECRET}` values in the example below with
 POST /connect/token HTTP/1.1
 Host: login.elfsquad.io
 Content-Type: application/x-www-form-urlencoded
-
 client_id={CLIENT_ID}&client_secret={CLIENT_SECRET}&grant_type=client_credentials&scope=Elfskot.Api
 ```
 </TabItem>
-
-Body (x-www-form-urlencoded):  
-|KEY               |VALUE             |
-|:-----------------|:-----------------|
-|client_id         |`{CLIENT_ID}`     |
-|client_secret     |`{CLIENT_SECRET}` |
-|grant_type        |client_credentials|
-|scope             |Elfskot.Api       |
-
 
 <TabItem value="curl">
 
@@ -73,7 +63,13 @@ Console.WriteLine(response.Content);
 </TabItem>
 </Tabs>
 
-     
+Body (x-www-form-urlencoded):  
+|KEY               |VALUE             |
+|:-----------------|:-----------------|
+|client_id         |`{CLIENT_ID}`     |
+|client_secret     |`{CLIENT_SECRET}` |
+|grant_type        |client_credentials|
+|scope             |Elfskot.Api       |     
 
 ## Step 2: Retrieve the access token from the response
 A successful response will look like this:

--- a/docs/authentication/client-credentials.md
+++ b/docs/authentication/client-credentials.md
@@ -29,9 +29,15 @@ Replace the `{CLIENT_ID}` and `{CLIENT_SECRET}` values in the example below with
 POST /connect/token HTTP/1.1
 Host: login.elfsquad.io
 Content-Type: application/x-www-form-urlencoded
-
-client_id={CLIENT_ID}&client_secret={CLIENT_SECRET}&grant_type=client_credentials&scope=Elfskot.Api
 ```
+
+Body (x-www-form-urlencoded):  
+|KEY               |VALUE             |
+|:-----------------|:-----------------|
+|client_id         |`{CLIENT_ID}`     |
+|client_secret     |`{CLIENT_SECRET}` |
+|grant_type        |client_credentials|
+|scope             |Elfskot.Api       |
 
 </TabItem>
 <TabItem value="curl">

--- a/docs/authentication/client-credentials.md
+++ b/docs/authentication/client-credentials.md
@@ -29,7 +29,10 @@ Replace the `{CLIENT_ID}` and `{CLIENT_SECRET}` values in the example below with
 POST /connect/token HTTP/1.1
 Host: login.elfsquad.io
 Content-Type: application/x-www-form-urlencoded
+
+client_id={CLIENT_ID}&client_secret={CLIENT_SECRET}&grant_type=client_credentials&scope=Elfskot.Api
 ```
+</TabItem>
 
 Body (x-www-form-urlencoded):  
 |KEY               |VALUE             |
@@ -39,7 +42,7 @@ Body (x-www-form-urlencoded):
 |grant_type        |client_credentials|
 |scope             |Elfskot.Api       |
 
-</TabItem>
+
 <TabItem value="curl">
 
 ``` bash

--- a/docs/authentication/client-credentials.md
+++ b/docs/authentication/client-credentials.md
@@ -29,6 +29,7 @@ Replace the `{CLIENT_ID}` and `{CLIENT_SECRET}` values in the example below with
 POST /connect/token HTTP/1.1
 Host: login.elfsquad.io
 Content-Type: application/x-www-form-urlencoded
+  
 client_id={CLIENT_ID}&client_secret={CLIENT_SECRET}&grant_type=client_credentials&scope=Elfskot.Api
 ```
 </TabItem>


### PR DESCRIPTION
Formatted HTTP request parameters as a table to clarify that the parameters should be included in a x-www-form-urlencoded Body (instead of the URI) for Postman users.