### PR TITLE
misc(EC-14710): use swagger v3 for the redoc website

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -118,7 +118,7 @@ module.exports = {
         specs: [
           {
             routePath: '/apis/data',
-            specUrl: "https://api.elfsquad.io/data/1/swagger/v2/swagger.json",
+            specUrl: "https://api.elfsquad.io/data/1/swagger/v2/swagger3.json",
           },
           {
             routePath: '/apis/configurator',


### PR DESCRIPTION
This is needed for us to deprecate operations/properties, since the `deprecated` field was only introduced in openapi v3.