### PR TITLE
Changed the link in quotationLines to authentication page

### DIFF
--- a/docs/guides/retrieve-quotation-lines-with-article-code.md
+++ b/docs/guides/retrieve-quotation-lines-with-article-code.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 :::info
 This guide assumes you've already familiarized yourself with the
-[Authentication](http://localhost:3000/docs/authentication/) page,
+[Authentication](https://docs.elfsquad.io/docs/authentication/) page,
 pagination and filtering.
 :::
 


### PR DESCRIPTION
the link in the guide quotationlines was linked to localhost page, changed to the authentication page.