### PR TITLE
Added pagination in custom scripting page to docs

### DIFF
--- a/docs/custom-scripting/pagination.md
+++ b/docs/custom-scripting/pagination.md
@@ -1,0 +1,25 @@
+---
+title: Pagination in custom scripting
+sidebar_position: 3
+sidebar_label: Pagination
+slug: pagination
+---
+
+Our custom scripting utilizes the Data API's pagination feature to efficiently retrieve large datasets, see [api.fetch](global-variables.md#apifetch). Pagination divides the data into manageable pages, improving performance and minimizing server load. The *@odata.nextLink* property supplies a URL to fetch the next page, ensuring optimal performance and resource usage.
+
+## Example
+This sample script demonstrate how custom scripting can be leveraged to retrieve all the quotations and not only the first 500. 
+
+``` js
+async function fetchAll(url) {
+    let nextUrl = url;
+    let result = [];
+    while (nextUrl) {
+        let response = await api.fetch(nextUrl);
+        result.push(...response.body.value);
+        nextUrl = response.body["@odata.nextLink"];
+    }
+    return result;
+}
+let resultaat = fetchAll(`data/1/quotations`);
+```

--- a/docs/guides/retrieve-quotation-lines-with-article-code.md
+++ b/docs/guides/retrieve-quotation-lines-with-article-code.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 :::info
 This guide assumes you've already familiarized yourself with the
-[Authentication](http://localhost:3000/docs/authentication/) page,
+[Authentication](https://docs.elfsquad.io/docs/authentication/) page,
 pagination and filtering.
 :::
 


### PR DESCRIPTION
I've added a page to the docs in custom scripting with an example of how you can retrieve all records instead of only the first 500. 